### PR TITLE
this.context is undefined in valueOut

### DIFF
--- a/lib/client/autoform-slingshot.coffee
+++ b/lib/client/autoform-slingshot.coffee
@@ -72,8 +72,8 @@ AutoForm.addInputType 'slingshotFileUpload',
     images
 
   valueOut: ->
-    fieldName = $(@context).data('schema-key')
-    templateInstanceId = $(@context).data('id')
+    fieldName = this.data('schema-key')
+    templateInstanceId = this.data('id')
     images = SlingshotAutoformFileCache.find({
       template: templateInstanceId
       field: fieldName

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: "timbrandin:autoform-slingshot",
   summary: "File upload for AutoForm with Slingshot",
   description: "File upload for AutoForm with Slingshot",
-  version: "1.1.2",
+  version: "1.1.3",
   git: "http://github.com/timbrandin/autoform-slingshot.git"
 });
 
@@ -19,9 +19,9 @@ function configure(api) {
     'templating',
     'less',
     'jquery',
-    'aldeed:autoform@5.3.0',
-    'edgee:slingshot@0.6.2',
-    "tap:i18n@1.5.1"
+    'aldeed:autoform',
+    'edgee:slingshot',
+    "tap:i18n"
   ], ['client', 'server']);
 
   api.imply([


### PR DESCRIPTION
In the current version of autoform, `this.context` is `undefined` in the `valueOut` function, so the image URL is never written to the field; it should just be `this`. I have also unpinned the versions of autoform, slingshot, and tapi18n.
